### PR TITLE
The draft for yolov3 and yolov3-tiny

### DIFF
--- a/dnn/model/yolov3-tiny.py
+++ b/dnn/model/yolov3-tiny.py
@@ -187,7 +187,7 @@ def YoloV3Tiny(size=None, channels=3, anchors=yolo_tiny_anchors, masks=yolo_tiny
     output_1 = YoloOutput(128, len(masks[1]), classes, name='yolo_output_1')(x)
 
     if training:
-        return Model(inputs, (output_0, output_1), name='yolov3')
+        return Model(inputs, (output_0, output_1), name='yolov3_tiny')
 
     boxes_0 = Lambda(lambda x: yolo_boxes(x, anchors[masks[0]], classes), name='yolo_boxes_0')(output_0)
     boxes_1 = Lambda(lambda x: yolo_boxes(x, anchors[masks[1]], classes), name='yolo_boxes_1')(output_1)

--- a/dnn/model/yolov3-tiny.py
+++ b/dnn/model/yolov3-tiny.py
@@ -1,0 +1,248 @@
+from absl import flags
+from absl.flags import FLAGS
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import Model
+from tensorflow.keras.layers import (
+    Add,
+    Concatenate,
+    Conv2D,
+    Input,
+    Lambda,
+    LeakyReLU,
+    MaxPool2D,
+    UpSampling2D,
+    ZeroPadding2D,
+    BatchNormalization,
+)
+from tensorflow.keras.regularizers import l2
+from tensorflow.keras.losses import binary_crossentropy
+
+flags.DEFINE_integer('yolo_max_boxes', 100, 'maximum number of boxes per image')
+flags.DEFINE_float('yolo_iou_threshold', 0.5, 'iou threshold')
+flags.DEFINE_float('yolo_score_threshold', 0.5, 'score threshold')
+flags.DEFINE_integer('class_number', 5, 'the number of classes')
+
+yolo_tiny_anchors = np.array([(10, 14), (23, 27), (37, 58), (81, 82), (135, 169), (344, 319)], np.float32) / 416
+yolo_tiny_anchor_masks = np.array([[3, 4, 5], [0, 1, 2]])
+
+
+def broadcast_iou(box_1, box_2):
+    # box_1: (..., (x1, y1, x2, y2))
+    # box_2: (N, (x1, y1, x2, y2))
+
+    # broadcast boxes
+    box_1 = tf.expand_dims(box_1, -2)
+    box_2 = tf.expand_dims(box_2, 0)
+    # new_shape: (..., N, (x1, y1, x2, y2))
+    new_shape = tf.broadcast_dynamic_shape(tf.shape(box_1), tf.shape(box_2))
+    box_1 = tf.broadcast_to(box_1, new_shape)
+    box_2 = tf.broadcast_to(box_2, new_shape)
+
+    int_w = tf.maximum(tf.minimum(box_1[..., 2], box_2[..., 2]) -
+                       tf.maximum(box_1[..., 0], box_2[..., 0]), 0)
+    int_h = tf.maximum(tf.minimum(box_1[..., 3], box_2[..., 3]) -
+                       tf.maximum(box_1[..., 1], box_2[..., 1]), 0)
+    int_area = int_w * int_h
+    box_1_area = (box_1[..., 2] - box_1[..., 0]) * (box_1[..., 3] - box_1[..., 1])
+    box_2_area = (box_2[..., 2] - box_2[..., 0]) * (box_2[..., 3] - box_2[..., 1])
+    return int_area / (box_1_area + box_2_area - int_area)
+
+
+def DarknetConv(x, filters, size, strides=1, batch_norm=True):
+    if strides == 1:
+        padding = 'same'
+    else:
+        x = ZeroPadding2D(((1, 0), (1, 0)))(x)
+        padding = 'valid'
+    x = Conv2D(filters=filters,
+               kernel_size=size,
+               strides=strides,
+               padding=padding,
+               use_bias=not batch_norm,
+               kernel_regularizer=l2(0.0005))(x)
+    if batch_norm:
+        x = BatchNormalization()(x)
+        x = LeakyReLU(alpha=0.1)(x)
+    return x
+
+
+def DarknetResidual(x, filters):
+    prev = x
+    x = DarknetConv(x, filters // 2, 1)
+    x = DarknetConv(x, filters, 3)
+    x = Add()([prev, x])
+    return x
+
+
+def DarknetBlock(x, filters, blocks):
+    x = DarknetConv(x, filters, 3, strides=2)
+    for _ in range(blocks):
+        x = DarknetResidual(x, filters)
+    return x
+
+
+def DarknetTiny(name=None):
+    x = inputs = Input([None, None, 3])
+    x = DarknetConv(x, 16, 3)
+    x = MaxPool2D(2, 2, 'same')(x)
+    x = DarknetConv(x, 32, 3)
+    x = MaxPool2D(2, 2, 'same')(x)
+    x = DarknetConv(x, 64, 3)
+    x = MaxPool2D(2, 2, 'same')(x)
+    x = DarknetConv(x, 128, 3)
+    x = MaxPool2D(2, 2, 'same')(x)
+    x = x_8 = DarknetConv(x, 256, 3)
+    x = MaxPool2D(2, 2, 'same')(x)
+    x = DarknetConv(x, 512, 3)
+    x = MaxPool2D(2, 1, 'same')(x)
+    x = DarknetConv(x, 1024, 3)
+    return tf.keras.Model(inputs, (x_8, x), name=name)
+
+
+def YoloConvTiny(filters, name=None):
+    def yolo_conv(x_in):
+        if isinstance(x_in, tuple):
+            inputs = Input(x_in[0].shape[1:]), Input(x_in[1].shape[1:])
+            x, x_skip = inputs
+            x = DarknetConv(x, filters, 1)
+            x = UpSampling2D(2)(x)
+            x = Concatenate()([x, x_skip])
+        else:
+            x = inputs = Input(x_in.shape[1:])
+            x = DarknetConv(x, filters, 1)
+        return Model(inputs, x, name=name)(x_in)
+    return yolo_conv
+
+
+def YoloOutput(filters, anchors, classes, name=None):
+    def yolo_output(x_in):
+        x = inputs = Input(x_in.shape[1:])
+        x = DarknetConv(x, filters * 2, 3)
+        x = DarknetConv(x, anchors * (classes + 5), 1, batch_norm=False)
+        x = Lambda(lambda x: tf.reshape(x, (-1, tf.shape(x)[1], tf.shape(x)[2], anchors, classes + 5)))(x)
+        return tf.keras.Model(inputs, x, name=name)(x_in)
+    return yolo_output
+
+
+def yolo_boxes(pred, anchors, classes):
+    # pred: (batch_size, grid, grid, anchors, (x, y, w, h, obj, ...classes))
+    grid_size = tf.shape(pred)[1:3]
+    box_xy, box_wh, objectness, class_probs = tf.split(pred, (2, 2, 1, classes), axis=-1)
+
+    box_xy = tf.sigmoid(box_xy)
+    objectness = tf.sigmoid(objectness)
+    class_probs = tf.sigmoid(class_probs)
+    pred_box = tf.concat((box_xy, box_wh), axis=-1)  # original xywh for loss
+
+    # grid[x][y] == (y, x)
+    grid = tf.meshgrid(tf.range(grid_size[1]), tf.range(grid_size[0]))
+    grid = tf.expand_dims(tf.stack(grid, axis=-1), axis=2)  # [gx, gy, 1, 2]
+
+    box_xy = (box_xy + tf.cast(grid, tf.float32)) / tf.cast(grid_size, tf.float32)
+    box_wh = tf.exp(box_wh) * anchors
+
+    box_x1y1 = box_xy - box_wh / 2
+    box_x2y2 = box_xy + box_wh / 2
+    bbox = tf.concat([box_x1y1, box_x2y2], axis=-1)
+
+    return bbox, objectness, class_probs, pred_box
+
+
+def yolo_nms(outputs):
+    # boxes, conf, type
+    b, c, t = [], [], []
+
+    for o in outputs:
+        b.append(tf.reshape(o[0], (tf.shape(o[0])[0], -1, tf.shape(o[0])[-1])))
+        c.append(tf.reshape(o[1], (tf.shape(o[1])[0], -1, tf.shape(o[1])[-1])))
+        t.append(tf.reshape(o[2], (tf.shape(o[2])[0], -1, tf.shape(o[2])[-1])))
+
+    bbox = tf.concat(b, axis=1)
+    confidence = tf.concat(c, axis=1)
+    class_probs = tf.concat(t, axis=1)
+
+    scores = confidence * class_probs
+    boxes, scores, classes, valid_detections = tf.image.combined_non_max_suppression(
+        boxes=tf.reshape(bbox, (tf.shape(bbox)[0], -1, 1, 4)),
+        scores=tf.reshape(scores, (tf.shape(scores)[0], -1, tf.shape(scores)[-1])),
+        max_output_size_per_class=FLAGS.yolo_max_boxes,
+        max_total_size=FLAGS.yolo_max_boxes,
+        iou_threshold=FLAGS.yolo_iou_threshold,
+        score_threshold=FLAGS.yolo_score_threshold
+    )
+
+    return boxes, scores, classes, valid_detections
+
+
+def YoloV3Tiny(size=None, channels=3, anchors=yolo_tiny_anchors, masks=yolo_tiny_anchor_masks, classes=FLAGS.class_number, training=False):
+    x = inputs = Input([size, size, channels], name='input')
+
+    x_8, x = DarknetTiny(name='yolo_darknet')(x)
+
+    x = YoloConvTiny(256, name='yolo_conv_0')(x)
+    output_0 = YoloOutput(256, len(masks[0]), classes, name='yolo_output_0')(x)
+
+    x = YoloConvTiny(128, name='yolo_conv_1')((x, x_8))
+    output_1 = YoloOutput(128, len(masks[1]), classes, name='yolo_output_1')(x)
+
+    if training:
+        return Model(inputs, (output_0, output_1), name='yolov3')
+
+    boxes_0 = Lambda(lambda x: yolo_boxes(x, anchors[masks[0]], classes), name='yolo_boxes_0')(output_0)
+    boxes_1 = Lambda(lambda x: yolo_boxes(x, anchors[masks[1]], classes), name='yolo_boxes_1')(output_1)
+    outputs = Lambda(lambda x: yolo_nms(x), name='yolo_nms')((boxes_0[:3], boxes_1[:3]))
+    return Model(inputs, outputs, name='yolov3_tiny')
+
+
+def YoloLoss(anchors, classes=FLAGS.class_number, ignore_thresh=0.5):
+    def yolo_loss(y_true, y_pred):
+        # 1. transform all pred outputs
+        # y_pred: (batch_size, grid, grid, anchors, (x, y, w, h, obj, ...cls))
+        pred_box, pred_obj, pred_class, pred_xywh = yolo_boxes(y_pred, anchors, classes)
+        pred_xy = pred_xywh[..., 0:2]
+        pred_wh = pred_xywh[..., 2:4]
+
+        # 2. transform all true outputs
+        # y_true: (batch_size, grid, grid, anchors, (x1, y1, x2, y2, obj, cls))
+        true_box, true_obj, true_class_idx = tf.split(y_true, (4, 1, 1), axis=-1)
+        true_xy = (true_box[..., 0:2] + true_box[..., 2:4]) / 2
+        true_wh = true_box[..., 2:4] - true_box[..., 0:2]
+
+        # give higher weights to small boxes
+        box_loss_scale = 2 - true_wh[..., 0] * true_wh[..., 1]
+
+        # 3. inverting the pred box equations
+        grid_size = tf.shape(y_true)[1]
+        grid = tf.meshgrid(tf.range(grid_size), tf.range(grid_size))
+        grid = tf.expand_dims(tf.stack(grid, axis=-1), axis=2)
+        true_xy = true_xy * tf.cast(grid_size, tf.float32) - tf.cast(grid, tf.float32)
+        true_wh = tf.math.log(true_wh / anchors)
+        true_wh = tf.where(tf.math.is_inf(true_wh), tf.zeros_like(true_wh), true_wh)
+
+        # 4. calculate all masks
+        obj_mask = tf.squeeze(true_obj, -1)
+        # ignore false positive when iou is over threshold
+        best_iou = tf.map_fn(
+            lambda x: tf.reduce_max(broadcast_iou(x[0], tf.boolean_mask(x[1], tf.cast(x[2], tf.bool))), axis=-1),
+            (pred_box, true_box, obj_mask),
+            tf.float32)
+        ignore_mask = tf.cast(best_iou < ignore_thresh, tf.float32)
+
+        # 5. calculate all losses
+        xy_loss = obj_mask * box_loss_scale * tf.reduce_sum(tf.square(true_xy - pred_xy), axis=-1)
+        wh_loss = obj_mask * box_loss_scale * tf.reduce_sum(tf.square(true_wh - pred_wh), axis=-1)
+        obj_loss = binary_crossentropy(true_obj, pred_obj)
+        obj_loss = obj_mask * obj_loss + (1 - obj_mask) * ignore_mask * obj_loss
+        true_class_one_hot = tf.one_hot(tf.cast(true_class_idx[..., 0], tf.int32), classes)
+        class_loss = obj_mask * binary_crossentropy(true_class_one_hot, pred_class)
+
+        # 6. sum over (batch, gridx, gridy, anchors) => (batch, 1)
+        xy_loss = tf.reduce_sum(xy_loss, axis=(1, 2, 3))
+        wh_loss = tf.reduce_sum(wh_loss, axis=(1, 2, 3))
+        obj_loss = tf.reduce_sum(obj_loss, axis=(1, 2, 3))
+        class_loss = tf.reduce_sum(class_loss, axis=(1, 2, 3))
+
+        return xy_loss + wh_loss + obj_loss + class_loss
+
+    return yolo_loss

--- a/dnn/model/yolov3.py
+++ b/dnn/model/yolov3.py
@@ -10,7 +10,6 @@ from tensorflow.keras.layers import (
     Input,
     Lambda,
     LeakyReLU,
-    MaxPool2D,
     UpSampling2D,
     ZeroPadding2D,
     BatchNormalization,
@@ -23,8 +22,8 @@ flags.DEFINE_float('yolo_iou_threshold', 0.5, 'iou threshold')
 flags.DEFINE_float('yolo_score_threshold', 0.5, 'score threshold')
 flags.DEFINE_integer('class_number', 5, 'the number of classes')
 
-yolo_tiny_anchors = np.array([(10, 14), (23, 27), (37, 58), (81, 82), (135, 169), (344, 319)], np.float32) / 416
-yolo_tiny_anchor_masks = np.array([[3, 4, 5], [0, 1, 2]])
+yolo_anchors = np.array([(10, 13), (16, 30), (33, 23), (30, 61), (62, 45), (59, 119), (116, 90), (156, 198), (373, 326)], np.float32) / 416
+yolo_anchor_masks = np.array([[6, 7, 8], [3, 4, 5], [0, 1, 2]])
 
 
 def broadcast_iou(box_1, box_2):
@@ -82,35 +81,33 @@ def DarknetBlock(x, filters, blocks):
     return x
 
 
-def DarknetTiny(name=None):
+def Darknet(name=None):
     x = inputs = Input([None, None, 3])
-    x = DarknetConv(x, 16, 3)
-    x = MaxPool2D(2, 2, 'same')(x)
     x = DarknetConv(x, 32, 3)
-    x = MaxPool2D(2, 2, 'same')(x)
-    x = DarknetConv(x, 64, 3)
-    x = MaxPool2D(2, 2, 'same')(x)
-    x = DarknetConv(x, 128, 3)
-    x = MaxPool2D(2, 2, 'same')(x)
-    x = x_8 = DarknetConv(x, 256, 3)
-    x = MaxPool2D(2, 2, 'same')(x)
-    x = DarknetConv(x, 512, 3)
-    x = MaxPool2D(2, 1, 'same')(x)
-    x = DarknetConv(x, 1024, 3)
-    return tf.keras.Model(inputs, (x_8, x), name=name)
+    x = DarknetBlock(x, 64, 1)
+    x = DarknetBlock(x, 128, 2)  # skip connection
+    x = x_36 = DarknetBlock(x, 256, 8)  # skip connection
+    x = x_61 = DarknetBlock(x, 512, 8)
+    x = DarknetBlock(x, 1024, 4)
+    return tf.keras.Model(inputs, (x_36, x_61, x), name=name)
 
 
-def YoloConvTiny(filters, name=None):
+def YoloConv(filters, name=None):
     def yolo_conv(x_in):
         if isinstance(x_in, tuple):
             inputs = Input(x_in[0].shape[1:]), Input(x_in[1].shape[1:])
             x, x_skip = inputs
+            # concat with skip connection
             x = DarknetConv(x, filters, 1)
             x = UpSampling2D(2)(x)
             x = Concatenate()([x, x_skip])
         else:
             x = inputs = Input(x_in.shape[1:])
-            x = DarknetConv(x, filters, 1)
+        x = DarknetConv(x, filters, 1)
+        x = DarknetConv(x, filters * 2, 3)
+        x = DarknetConv(x, filters, 1)
+        x = DarknetConv(x, filters * 2, 3)
+        x = DarknetConv(x, filters, 1)
         return Model(inputs, x, name=name)(x_in)
     return yolo_conv
 
@@ -175,24 +172,27 @@ def yolo_nms(outputs):
     return boxes, scores, classes, valid_detections
 
 
-def YoloV3Tiny(size=None, channels=3, anchors=yolo_tiny_anchors, masks=yolo_tiny_anchor_masks, classes=FLAGS.class_number, training=False):
+def YoloV3(size=None, channels=3, anchors=yolo_anchors, masks=yolo_anchor_masks, classes=80, training=False):
     x = inputs = Input([size, size, channels], name='input')
 
-    x_8, x = DarknetTiny(name='yolo_darknet')(x)
+    x_36, x_61, x = Darknet(name='yolo_darknet')(x)
 
-    x = YoloConvTiny(256, name='yolo_conv_0')(x)
-    output_0 = YoloOutput(256, len(masks[0]), classes, name='yolo_output_0')(x)
-    x = YoloConvTiny(128, name='yolo_conv_1')((x, x_8))
-    output_1 = YoloOutput(128, len(masks[1]), classes, name='yolo_output_1')(x)
+    x = YoloConv(512, name='yolo_conv_0')(x)
+    output_0 = YoloOutput(512, len(masks[0]), classes, name='yolo_output_0')(x)
+    x = YoloConv(256, name='yolo_conv_1')((x, x_61))
+    output_1 = YoloOutput(256, len(masks[1]), classes, name='yolo_output_1')(x)
+    x = YoloConv(128, name='yolo_conv_2')((x, x_36))
+    output_2 = YoloOutput(128, len(masks[2]), classes, name='yolo_output_2')(x)
 
     if training:
-        return Model(inputs, (output_0, output_1), name='yolov3_tiny')
+        return Model(inputs, (output_0, output_1, output_2), name='yolov3')
 
     boxes_0 = Lambda(lambda x: yolo_boxes(x, anchors[masks[0]], classes), name='yolo_boxes_0')(output_0)
     boxes_1 = Lambda(lambda x: yolo_boxes(x, anchors[masks[1]], classes), name='yolo_boxes_1')(output_1)
+    boxes_2 = Lambda(lambda x: yolo_boxes(x, anchors[masks[2]], classes), name='yolo_boxes_2')(output_2)
 
-    outputs = Lambda(lambda x: yolo_nms(x), name='yolo_nms')((boxes_0[:3], boxes_1[:3]))
-    return Model(inputs, outputs, name='yolov3_tiny')
+    outputs = Lambda(lambda x: yolo_nms(x), name='yolo_nms')((boxes_0[:3], boxes_1[:3], boxes_2[:3]))
+    return Model(inputs, outputs, name='yolov3')
 
 
 def YoloLoss(anchors, classes=FLAGS.class_number, ignore_thresh=0.5):


### PR DESCRIPTION
This is a revised version from yolov3-tf project.
1. Deleted unnecessary parts for tiny.
2. Changed lost function implementation from sparse_categorical_crossentropy to binary_crossentropy.
3. Changed the class number from 80 to 5, and instead of fixed integer, now you can change it as a flexible parameter within absl.
4. Removed unnecessary extra parameters for yolo_nms.
5. Several minor fixes.