### PR TITLE
Fix LCMLoggerDecoder Test Failing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(iRM CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-set(CMAKE_CXX_STANDARD 14)  # use c++14
+set(CMAKE_CXX_STANDARD 17)  # use c++17
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wextra") # low warning tolerance
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG") # add debug flag for debug build
 

--- a/cmake/irm_cmake_utils.cmake
+++ b/cmake/irm_cmake_utils.cmake
@@ -52,7 +52,7 @@ endfunction()
 #   all generated python modules will go to ${PROJECT_BINARY_DIR}/python_bindings
 function(irm_add_python_module module_name)
     cmake_parse_arguments(PYBIND "" "" "SOURCES;DEPENDS" ${ARGN})
-    pybind11_add_module(${module_name} ${PYBIND_SOURCES})
+    pybind11_add_module(${module_name} SYSTEM ${PYBIND_SOURCES})
     target_link_libraries(${module_name} PRIVATE ${PYBIND_DEPENDS})
     set_target_properties(${module_name} PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${IRM_PYTHON_MODULE_DIR})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -9,8 +9,10 @@ target_compile_options(lcm-logger PRIVATE
     $<$<PLATFORM_ID:Linux>:-Wno-format-truncation>
     "-Wno-#pragma-messages"
     -Wno-implicit-function-declaration)
+
 # gtest
 add_subdirectory(googletest-1.10.0)
+
 # pybind11
 set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 add_subdirectory(pybind11-2.5.0)

--- a/utils/tests/lcm_utils_test.cc
+++ b/utils/tests/lcm_utils_test.cc
@@ -12,11 +12,11 @@
 #define TEMP_LOG_PRODUCT "/tmp/lcm_utils_test.lcmlog"
 
 class LCMUtilsTest : public TestBase {
- public:
+ protected:
   /**
    * @brief example usage of LCMFileLogger and expected behaviors
    */
-  void LCMFileLoggerTest() {
+  void SetUp() override {
     lcm::LCM lcm_backend;
     lcm::LCMFileLogger logger(TEMP_LOG_PRODUCT);
     // test: consecutive start should fail
@@ -113,6 +113,5 @@ class LCMUtilsTest : public TestBase {
   }
 };
 
-TEST_FM(LCMUtilsTest, LCMFileLoggerTest);
 TEST_FM(LCMUtilsTest, LCMDecodeTest);
 

--- a/utils/tests/lcm_utils_test.cc
+++ b/utils/tests/lcm_utils_test.cc
@@ -57,7 +57,7 @@ class LCMUtilsTest : public TestBase {
     EXPECT_EQ(logger.Start(false), 0);
     EXPECT_EQ(logger.Start(false), -1);
     EXPECT_EQ(lcm_backend.publish("INT32_VEC3D", &vec3d), 0);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     // test: logger goes out of scope should automatically stop logging
   }
 


### PR DESCRIPTION
Fix #36. 

Logger test is put into `SetUp` to ensure being executed before the `Decoder` test. A longer delay is also added to prevent the logger from dropping the last message.